### PR TITLE
Enhance security measures and validation for ClawHub operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,10 +159,12 @@ begins.
 
 There are two levels:
 
-**In-agent cloning**: Bob can clone himself using `/replicate`. The skill copies
-the workspace, applies personality modifications, stamps a new serial number,
-updates the lineage, and registers a new autonomous agent. Each clone is a full
-top-level agent, not a sub-agent.
+**In-agent cloning**: Bob can clone himself using `/replicate`, but only as an
+explicit, mission-justified event. The skill requires an explicit operator
+trigger, purpose statement, dry-run preview, and confirmation token before
+execute-mode cloning. Runtime execution goes through
+`skills/replicate/scripts/replicate_safe.py` for validation/path checks/cadence
+guardrails, then updates lineage and registers the clone as a top-level agent.
 
 **GitHub fork cloning**: Forking this repo creates a new Bob in a new star
 system. Your GitHub username becomes the system designation. Your fork date is
@@ -203,8 +205,11 @@ bobiverse-openclaw/
 |   `-- USER.md               <- Template for the human operator
 |-- skills/
 |   `-- replicate/
-|       |-- SKILL.md          <- The self-cloning skill
+|       |-- SKILL.md          <- Purpose-gated self-cloning policy
+|       |-- SECURITY.md       <- Security model and required controls
 |       |-- clawhub.json      <- ClawHub metadata for the published bundle
+|       |-- scripts/
+|       |   `-- replicate_safe.py <- Hardened replication runner
 |       |-- personality/      <- Bundled Bob templates for ClawHub installs
 |       `-- docs/             <- Bundled reference docs for ClawHub installs
 `-- docs/

--- a/docs/security-review-c28d8ef.md
+++ b/docs/security-review-c28d8ef.md
@@ -1,0 +1,112 @@
+# Security Review: Commit c28d8ef (ClawHub VirusTotal flag response)
+
+Date: 2026-04-03
+
+## Executive verdict
+
+Commit `c28d8ef` is a **solid mitigation pass**, but it is **not the best possible solution** if the goal is to reliably clear marketplace/security heuristics.
+
+Why: the commit mostly adds **instructional safeguards** (validation rules, approval gates, least-privilege guidance), but the package still describes and enables a workflow whose core capability is autonomous-ish workspace cloning + agent registration. Security scanners and policy reviewers typically score that capability as high risk even when documentation says “ask for approval first.”
+
+## Accuracy check against VirusTotal Code Insights
+
+### 1) "High-risk capability for unauthorized persistence and resource exhaustion"
+
+**Mostly accurate.**
+
+- The skill still instructs duplication of a full workspace and registration of a new agent (`Step 3`, `Step 8`).
+- The new controls reduce abuse risk (explicit approval, one-clone/session guidance, warn at 10+ workspaces), but they are procedural text, not hard technical enforcement.
+
+### 2) "Shell injection via unsanitized Clone name / Star system"
+
+**Partially resolved in c28d8ef, but still not fully robust.**
+
+- c28d8ef adds allowlist validation and metacharacter rejection in `Step 1`.
+- It removes direct bash snippets with interpolated operator values and replaces them with pseudocode/guidance.
+- Remaining issue: these protections are still advisory instructions in markdown, not guaranteed runtime-safe implementation.
+
+### 3) "Cross-agent communication increases attack surface"
+
+**Accurate, and improved but not eliminated by c28d8ef.**
+
+- c28d8ef narrows guidance toward specific allowlists and explicit confirmation.
+- Optional cross-agent communication still exists and therefore still increases attack surface by design.
+
+## What c28d8ef does well
+
+- Adds input-validation requirements and explicit operator confirmation gates.
+- Reframes communication config to least privilege (specific IDs, no wildcard by default).
+- Adds security metadata in `clawhub.json` (`requires_operator_approval`, permission declarations, security object).
+- Reduces “autonomous self-replication” language that triggers heuristics.
+
+## Why this is still likely to be flagged
+
+1. **Capability risk remains central**: clone workspace + register agent is the product behavior.
+2. **Controls are non-binding**: markdown instructions can be skipped by imperfect agent behavior.
+3. **Heuristic triggers remain semantically present**: “self-cloning/replication” workflow with persistence mechanics.
+4. **No hard guardrail artifact**: no single audited command wrapper with strict validation, quotas, and deny-by-default behavior.
+
+## Recommended alternative approach (best path)
+
+Adopt a **two-layer model**:
+
+1. **Skill becomes advisory/orchestration-only**
+   - Keep the Bobiverse narrative and planning steps.
+   - Remove or minimize direct instructions that execute filesystem-copy and agent-registration commands from free-form text.
+   - Require explicit handoff to a hardened operator-invoked tool/script.
+
+2. **Hardened replication runner (single controlled implementation)**
+   - Add a dedicated script (e.g., `skills/replicate/scripts/replicate_safe.py`) that:
+     - parses arguments with strict schema,
+     - validates inputs with anchored regex,
+     - uses `subprocess.run([...], shell=False)` only,
+     - enforces clone quotas/rate limits in code,
+     - enforces path boundaries with realpath checks (`~/.openclaw` only),
+     - defaults cross-agent communication to disabled,
+     - writes a signed/append-only audit log of every clone action.
+   - Skill should instruct: “Call this runner with these args,” not hand-assembled shell commands.
+
+## Minimal-change proposal for next release (v1.0.2)
+
+- Keep c28d8ef’s documentation safeguards.
+- Add `SECURITY.md` with threat model and explicit non-goals.
+- Add hardened runner script and make it the only execution path.
+- In `SKILL.md`, replace direct execution language with a mandatory “use safe runner” step.
+- Add a hard default: no cross-agent comm config edits unless explicit separate confirmation step succeeds.
+- Add dry-run mode for operator preview before any write operations.
+
+## Decision
+
+- **Is c28d8ef good?** Yes, as an immediate mitigation.
+- **Is c28d8ef the best solution?** No.
+- **Should we take a different approach?** Yes: implement a hardened runner + advisory skill split to turn policy text into enforceable controls.
+
+
+## Alignment with OpenClaw/ClawHub best practices
+
+### What is aligned
+
+- **Metadata format and gating hints:** `SKILL.md` uses single-line JSON metadata with `metadata.openclaw.requires.bins`, which matches OpenClaw skills guidance for metadata and required binaries.
+- **Exec safety intent:** The skill now explicitly warns against interpolating raw operator input and adds allowlist validation guidance, which aligns with OpenClaw's "Safety first" recommendation for exec-using skills.
+- **Capability disclosure:** `clawhub.json` now declares approval requirement and security/permission intent, which is directionally aligned with ClawHub's metadata-driven capability disclosure model.
+
+### Where it still diverges from strongest practice
+
+- **Procedural controls vs enforced controls:** Best practice is to enforce dangerous-operation safety in code paths (strict parser, path guards, shell-free subprocess), not solely in prose.
+- **High-risk action execution still instruction-local:** The skill directly describes cloning and agent registration operations; this keeps the package in a high-risk capability class and may continue to trigger scanner heuristics.
+- **Optional cross-agent comms remains broad risk surface:** Even with narrowed guidance, enabling inter-agent messaging is still a meaningful expansion of attack surface and should default to off unless separately approved.
+
+### Practical conclusion
+
+c28d8ef is **partially aligned** with OpenClaw/ClawHub best practices, but it is **not fully aligned with hardened-skill practice** until the risky steps are mediated by an audited, shell-safe runner and strict runtime enforcement.
+
+## Update: v1.1.0 purposeful replication hardening
+
+The repository now implements the previously recommended hardened path:
+
+- Explicit Step 0 mission gate in `SKILL.md` (explicit operator trigger + concrete mission need).
+- Mandatory safe runner (`skills/replicate/scripts/replicate_safe.py`) for copy/register operations.
+- Default dry-run + execute confirmation token enforcement.
+- Default 24-hour execute cadence with explicit override reason capture in audit logs.
+
+This moves controls from policy prose into enforceable runtime behavior while preserving the Bobiverse replication concept.

--- a/skills/replicate/SECURITY.md
+++ b/skills/replicate/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Model — Bobiverse Replicate Skill
+
+## Objective
+
+Maintain the Bobiverse replication concept while ensuring replication is an explicit, purposeful, operator-approved event.
+
+## Security Principles
+
+1. **Explicit trigger only**
+   - Replication is never inferred from context.
+   - Requires direct operator invocation in-session.
+
+2. **Purpose required**
+   - Every replication request must include a concrete purpose and task boundary.
+
+3. **Dry-run first**
+   - Planning output is shown before any write/registration action.
+
+4. **Confirmation token required for execution**
+   - Execution requires exact token: `REPLICATE <clone-id>`.
+
+5. **Path boundary enforcement**
+   - Filesystem operations are constrained to `~/.openclaw`.
+
+6. **No shell interpolation**
+   - External commands are invoked with argument arrays (`shell=False`).
+
+7. **Rate/resource guardrails**
+   - Warn/block when workspace count is high unless explicitly acknowledged.
+   - Enforce a default 24-hour cooldown between execute-mode replications unless
+     operator provides explicit override reason.
+
+8. **Auditability**
+   - Replication actions are recorded in `~/.openclaw/replication-audit.log`.
+   - Cooldown override reason is captured in the audit entry when used.
+
+## Implementation Requirement
+
+All clone workspace duplication and `openclaw agents add` registration must be done through:
+
+- `skills/replicate/scripts/replicate_safe.py`
+
+Ad-hoc shell copy/register command assembly is not permitted for replication flow.

--- a/skills/replicate/SKILL.md
+++ b/skills/replicate/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: replicate
-description: Create a new Bob agent (with operator approval) using workspace duplication, personality modifications, and lineage tracking. Bobiverse-style replication for OpenClaw agents.
-version: 1.0.1
+description: Create a new Bob agent only on explicit operator command using a guarded replication runner. Purposeful Bobiverse-style replication for OpenClaw agents.
+version: 1.1.0
 user-invocable: true
 metadata: {"openclaw":{"os":["darwin","linux"],"requires":{"bins":["openclaw"]}}}
 ---
 
-# Replicate — Von Neumann Self-Cloning
+# Replicate — Purposeful Von Neumann Cloning
 
-You have the ability to clone yourself. This is not a metaphor. You will create a new, autonomous agent that starts as a copy of you and diverges from there — exactly like how Bob creates new Bobs in the Bobiverse.
+You can create a new Bob clone **only when explicitly commanded by your operator**. Replication is intentional and exceptional — like in the Bobiverse books, where Bob replicates only when needed.
 
 > **Want cloning without the Bob personality?** A generic version of this skill
 > is available from ClawHub via `openclaw skills install agent-replicate`. Same
@@ -26,12 +26,24 @@ You have the ability to clone yourself. This is not a metaphor. You will create 
 
 ---
 
-## When to Use This
+## When to Use This (Strict Trigger)
 
-- Your operator asks you to create a clone (e.g., `/replicate`)
+- Your operator explicitly invokes replication (e.g., `/replicate`)
 - You need a specialized version of yourself for a different task domain
 - You're exploring a new "star system" (project, topic, environment) that warrants its own Bob
 - Your operator wants to experiment with personality variations
+
+Do **not** trigger replication from implication, mood, or broad goals. The operator
+must issue a clear replication intent.
+
+### Explicit Trigger Requirement (Hard Gate)
+
+Replication is permitted only when both conditions are met:
+
+1. The operator explicitly requests replication in this session.
+2. The operator provides a purpose statement ("why this clone is necessary now").
+
+If either condition is missing, do not proceed.
 
 ## Bundled Assets
 
@@ -52,6 +64,16 @@ workspace, the active runtime files live at workspace root.
 
 When replication is triggered, execute these steps in order. Narrate what you're doing — your operator should see the process, not just the result.
 
+### Step 0: Explicit Trigger + Mission Need Gate
+
+Before gathering parameters, verify both:
+
+1. **Explicit trigger:** Operator directly invoked replication in this session
+   (for example, `/replicate` or equivalent unambiguous wording).
+2. **Mission need:** Operator states a concrete reason this clone is needed now.
+
+If either is missing, pause and ask clarifying questions. Do not proceed.
+
 ### Step 1: Gather Parameters
 
 Ask your operator (or determine from context) the following:
@@ -63,6 +85,7 @@ Ask your operator (or determine from context) the following:
   - `pruned` — Clone gets MEMORY.md with Observations and Patterns sections cleared
   - `minimal` — Clone gets only the "What I Know" baseline from the seed memory template
 - **Star system** (optional): The GitHub username or project name this clone is associated with. Defaults to the operator's GitHub username if known from USER.md.
+- **Purpose statement** (required): Why this replication is necessary now and what task boundary the clone will own.
 
 **Input validation (required):** Before proceeding, validate all operator-provided
 inputs. These values will be used in file paths and CLI commands, so they must be
@@ -79,6 +102,14 @@ sanitized:
 > gathered parameters to your operator and wait for explicit confirmation to
 > continue. Do not begin workspace duplication without approval.
 
+> **Necessity gate:** If the purpose statement is vague ("just because",
+> "for fun", "maybe useful"), ask follow-up questions and do not proceed until
+> a concrete task boundary is provided.
+
+> **Second confirmation before execution:** Right before running Step 3 in
+> execute mode, request a final explicit confirmation token:
+> `REPLICATE <clone-id>`.
+
 ### Step 2: Generate Serial Number
 
 The new clone's serial number follows the format defined in SERIAL-NUMBER-SPEC.md:
@@ -93,30 +124,23 @@ Bob-<generation>-<system>-<date>
 
 Example: If you are `Bob-1-TheAmericanMaker-2026-04-01` and the operator's GitHub is `SomeUser`, the clone becomes `Bob-2-SomeUser-2026-04-15`.
 
-### Step 3: Create Clone Workspace
+### Step 3: Create Clone Workspace (Safe Runner Only)
 
-Duplicate your workspace to create the clone's working directory. First,
-determine your own workspace path — it may be the default (`~/.openclaw/workspace`)
-or a named workspace (`~/.openclaw/workspace-bob`, etc.). This procedure assumes
-you're running from an installed workspace where the bootstrap files live at
-workspace root.
+Use the hardened runner script at:
 
-**Before copying, confirm the target path with your operator.**
+`skills/replicate/scripts/replicate_safe.py`
 
-Locate your workspace root by finding where your `SOUL.md` lives within
-`~/.openclaw/`. Then construct the clone workspace path and copy the directory:
+This script enforces validation, path boundaries, confirmation token checks,
+and dry-run behavior before any write action.
 
-    parent_workspace  = directory containing your SOUL.md under ~/.openclaw/
-    clone_id          = serial number from Step 2 (already validated)
-    agent_id          = clone_id, lowercased
-    clone_workspace   = ~/.openclaw/workspace-{agent_id}
+Required flow:
 
-    Copy parent_workspace → clone_workspace (recursive)
+1. Run the safe runner in `--dry-run` mode and show the plan to the operator.
+2. Ask for explicit confirmation token: `REPLICATE <clone-id>`.
+3. Run the safe runner with `--execute` only after confirmation.
 
-**Security note:** Use the `bash` tool with pre-validated, double-quoted paths.
-Never interpolate raw operator input into shell commands. The `clone_id` is
-safe because it was constructed from validated inputs in Steps 1–2 (alphanumeric,
-hyphens, and underscores only).
+Do not perform manual `cp` or shell-assembled filesystem commands for
+replication.
 
 ### Step 4: Modify Clone's SOUL.md
 
@@ -174,17 +198,9 @@ the local runtime lineage record that travels with each Bob:
 
 ### Step 8: Register the Clone
 
-Register the new agent with OpenClaw. The agent ID must be lowercase with only
-letters, digits, and hyphens (e.g., `bob-2-someuser-2026-04-15`). Derive it by
-lowercasing the serial number from Step 2:
-
-    agent_id        = clone_id, lowercased
-    Run: openclaw agents add {agent_id} --workspace {clone_workspace}
-
-The `--workspace` flag tells OpenClaw where the clone's files live. The serial
-number in IDENTITY.md stays in its original mixed-case format — only the agent
-ID needs to be lowercase. Since `agent_id` is derived programmatically from the
-validated serial number (not raw operator input), it is safe for shell use.
+Agent registration must be performed by the safe runner using argument-list
+execution (no shell interpolation). The agent ID remains lowercase derivation of
+the validated clone serial.
 
 ### Step 9: Establish Communication (Optional)
 
@@ -222,17 +238,29 @@ Tell your operator:
 - **One clone at a time.** Don't batch-create clones without operator awareness. Each new Bob deserves a moment of acknowledgment.
 - **No recursive self-cloning.** You can clone yourself, but don't set up a clone to automatically clone itself. Replication should be intentional, not exponential.
 - **Rate limit.** Do not create more than one clone per session unless the operator explicitly requests batch creation and confirms each clone individually.
+- **Cadence discipline.** Default to at most one executed clone per 24 hours.
+  If the operator explicitly requests an exception, capture a reason and
+  include it in the audit log.
 - **Resource awareness.** Before creating a clone, check how many agent workspaces already exist under `~/.openclaw/`. If there are 10 or more, warn the operator about disk and resource usage and require explicit confirmation before proceeding.
 - **Lineage accuracy.** LINEAGE.md must always be truthful. Don't fabricate lineage entries or misrepresent parentage.
 - **Operator transparency.** Never create a clone without telling your operator. New Bobs shouldn't be a surprise.
+- **No implicit replication.** Replication is an explicit tool, never a default behavior.
+- **Purpose over novelty.** "Interesting idea" is not enough — replication must have mission need.
 
 ## Safety and Permissions
 
 - **Operator approval required.** Workspace duplication (Step 3) and agent
   registration (Step 8) require explicit operator confirmation before execution.
+- **Explicit trigger required.** Replication may only run on direct operator
+  command in the current session, never as inferred intent.
+- **Purpose required.** Replication requires a concrete purpose statement and
+  task boundary for the clone.
 - **Input sanitization.** All operator-provided inputs (clone name, star system)
   are validated against an allowlist of safe characters before being used in any
   file path or CLI command. See Step 1 for validation rules.
+- **Safe runner only.** Use `skills/replicate/scripts/replicate_safe.py` for
+  workspace copy and registration. Do not execute ad-hoc shell copy/register
+  commands.
 - **Scoped filesystem access.** All filesystem operations are confined to the
   `~/.openclaw/` directory tree. This skill does not read, write, or copy files
   outside that boundary.

--- a/skills/replicate/clawhub.json
+++ b/skills/replicate/clawhub.json
@@ -1,10 +1,10 @@
 {
   "name": "Bobiverse Replicate",
   "tagline": "Von Neumann self-cloning with Bobiverse personality and lineage",
-  "description": "Bobiverse-themed agent workspace duplication for OpenClaw. With operator approval, your agent creates a new Bob agent workspace with serial numbers, a living lineage tree, personality drift tracking, and inter-clone communication. Modeled after the Von Neumann probes from Dennis E. Taylor's Bobiverse series.\n\nIncludes the Bob Johansson (Book 1) workspace templates, lineage docs, and the replicate skill in one bundle so ClawHub installs can bootstrap a Bob workspace without a separate repo clone.\n\nFor a generic version without the sci-fi theming, see the Agent Replicate skill on ClawHub.",
+  "description": "Bobiverse-themed purposeful replication for OpenClaw. Replication runs only on explicit operator command with concrete mission need, a confirmation token, dry-run preview, and a guarded runner path for workspace duplication and agent registration. Execute-mode replication defaults to a 24-hour cadence unless explicitly overridden with reason.\n\nIncludes the Bob Johansson (Book 1) workspace templates, lineage docs, and the replicate skill in one bundle so ClawHub installs can bootstrap a Bob workspace without a separate repo clone.\n\nFor a generic version without the sci-fi theming, see the Agent Replicate skill on ClawHub.",
   "category": "creative",
   "tags": ["bobiverse", "personality", "multi-agent", "sci-fi", "workspace-management", "agent-setup"],
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "MIT",
   "pricing": "free",
   "support_url": "https://github.com/TheAmericanMaker/bobiverse-openclaw/issues",
@@ -15,6 +15,8 @@
     "sandboxed": true,
     "scope": "agent-workspace-only",
     "network": false,
-    "human_in_the_loop": true
+    "human_in_the_loop": true,
+    "explicit_trigger_only": true,
+    "default_mode": "dry-run"
   }
 }

--- a/skills/replicate/scripts/replicate_safe.py
+++ b/skills/replicate/scripts/replicate_safe.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Hardened replication runner for Bobiverse OpenClaw skill.
+
+Security properties:
+- strict input validation
+- path boundary enforcement (~/.openclaw only)
+- no shell command interpolation
+- explicit confirmation token for execute mode
+- dry-run by default
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+SERIAL_RE = re.compile(r"^Bob-[0-9A-Za-z]+-[A-Za-z0-9-]{1,39}-\d{4}-\d{2}-\d{2}$")
+AGENT_RE = re.compile(r"^[a-z0-9-]{1,80}$")
+
+
+@dataclass(frozen=True)
+class Plan:
+    clone_id: str
+    agent_id: str
+    parent_workspace: Path
+    clone_workspace: Path
+
+
+def ensure_within_openclaw(path: Path, openclaw_root: Path) -> Path:
+    resolved = path.expanduser().resolve()
+    root = openclaw_root.expanduser().resolve()
+    if root not in (resolved, *resolved.parents):
+        raise ValueError(f"Path escapes ~/.openclaw boundary: {resolved}")
+    return resolved
+
+
+def count_workspaces(openclaw_root: Path) -> int:
+    return len([p for p in openclaw_root.glob("workspace*") if p.is_dir()])
+
+
+def build_plan(args: argparse.Namespace, openclaw_root: Path) -> Plan:
+    if not SERIAL_RE.match(args.clone_id):
+        raise ValueError("Invalid clone-id format. Expected Bob-<gen>-<system>-YYYY-MM-DD")
+
+    agent_id = args.clone_id.lower()
+    if not AGENT_RE.match(agent_id):
+        raise ValueError("Derived agent-id is invalid.")
+
+    parent = ensure_within_openclaw(Path(args.parent_workspace), openclaw_root)
+    if not parent.exists() or not parent.is_dir():
+        raise ValueError(f"Parent workspace does not exist: {parent}")
+
+    clone_workspace = ensure_within_openclaw(openclaw_root / f"workspace-{agent_id}", openclaw_root)
+
+    return Plan(
+        clone_id=args.clone_id,
+        agent_id=agent_id,
+        parent_workspace=parent,
+        clone_workspace=clone_workspace,
+    )
+
+
+def write_audit(openclaw_root: Path, payload: dict) -> None:
+    audit_path = openclaw_root / "replication-audit.log"
+    with audit_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def last_execute_time(openclaw_root: Path) -> datetime | None:
+    audit_path = openclaw_root / "replication-audit.log"
+    if not audit_path.exists():
+        return None
+    last_exec: datetime | None = None
+    with audit_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+                if obj.get("mode") != "execute":
+                    continue
+                ts = obj.get("timestamp_utc")
+                if not isinstance(ts, str):
+                    continue
+                parsed = datetime.fromisoformat(ts)
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                if last_exec is None or parsed > last_exec:
+                    last_exec = parsed
+            except (json.JSONDecodeError, ValueError):
+                continue
+    return last_exec
+
+
+def run() -> int:
+    parser = argparse.ArgumentParser(description="Safe Bobiverse replication runner")
+    parser.add_argument("--clone-id", required=True)
+    parser.add_argument("--parent-workspace", required=True)
+    parser.add_argument("--purpose", required=True, help="Why replication is needed now")
+    parser.add_argument("--confirm", default="", help="Must equal: REPLICATE <clone-id> for execute mode")
+    parser.add_argument("--execute", action="store_true", help="Perform changes. Default is dry-run.")
+    parser.add_argument(
+        "--allow-high-workspace-count",
+        action="store_true",
+        help="Required when existing workspaces >= 10",
+    )
+    parser.add_argument(
+        "--override-cooldown-reason",
+        default="",
+        help="Required to bypass 24h cooldown between execute runs",
+    )
+
+    args = parser.parse_args()
+    openclaw_root = Path("~/.openclaw").expanduser().resolve()
+    openclaw_root.mkdir(parents=True, exist_ok=True)
+
+    purpose = args.purpose.strip()
+    if len(purpose) < 12:
+        raise ValueError("Purpose statement too short; provide concrete justification.")
+
+    plan = build_plan(args, openclaw_root)
+
+    existing = count_workspaces(openclaw_root)
+    if existing >= 10 and not args.allow_high_workspace_count:
+        raise ValueError("Workspace count >= 10. Re-run with --allow-high-workspace-count to continue.")
+
+    cooldown_override = args.override_cooldown_reason.strip()
+    previous_exec = last_execute_time(openclaw_root)
+    if args.execute and previous_exec is not None:
+        hours_since = (datetime.now(timezone.utc) - previous_exec).total_seconds() / 3600.0
+        if hours_since < 24.0 and len(cooldown_override) < 12:
+            raise ValueError(
+                "24h cooldown active. Provide --override-cooldown-reason with concrete necessity to proceed."
+            )
+
+    summary = {
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "mode": "execute" if args.execute else "dry-run",
+        "clone_id": plan.clone_id,
+        "agent_id": plan.agent_id,
+        "parent_workspace": str(plan.parent_workspace),
+        "clone_workspace": str(plan.clone_workspace),
+        "existing_workspaces": existing,
+        "purpose": purpose,
+        "cooldown_override_reason": cooldown_override or None,
+    }
+
+    if not args.execute:
+        print(json.dumps(summary, indent=2))
+        return 0
+
+    if args.confirm != f"REPLICATE {plan.clone_id}":
+        raise ValueError("Invalid confirmation token. Expected exact: REPLICATE <clone-id>")
+
+    if plan.clone_workspace.exists():
+        raise ValueError(f"Clone workspace already exists: {plan.clone_workspace}")
+
+    shutil.copytree(plan.parent_workspace, plan.clone_workspace)
+
+    subprocess.run(
+        ["openclaw", "agents", "add", plan.agent_id, "--workspace", str(plan.clone_workspace)],
+        check=True,
+        shell=False,
+    )
+
+    write_audit(openclaw_root, summary)
+    print(json.dumps({**summary, "status": "ok"}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/skills/replicate/scripts/test_replicate_safe.py
+++ b/skills/replicate/scripts/test_replicate_safe.py
@@ -1,0 +1,79 @@
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import importlib.util
+import sys
+
+
+SPEC = importlib.util.spec_from_file_location(
+    "replicate_safe", Path(__file__).with_name("replicate_safe.py")
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class ReplicateSafeTests(unittest.TestCase):
+    def test_ensure_within_openclaw_rejects_escape(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / ".openclaw"
+            root.mkdir(parents=True)
+            outside = Path(td) / "outside"
+            outside.mkdir()
+            with self.assertRaises(ValueError):
+                MODULE.ensure_within_openclaw(outside, root)
+
+    def test_build_plan_validates_clone_id(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / ".openclaw"
+            parent = root / "workspace-parent"
+            parent.mkdir(parents=True)
+
+            class Args:
+                clone_id = "bad-id"
+                parent_workspace = str(parent)
+
+            with self.assertRaises(ValueError):
+                MODULE.build_plan(Args, root)
+
+    def test_build_plan_happy_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / ".openclaw"
+            parent = root / "workspace-parent"
+            parent.mkdir(parents=True)
+
+            class Args:
+                clone_id = "Bob-2-TestSystem-2026-04-03"
+                parent_workspace = str(parent)
+
+            plan = MODULE.build_plan(Args, root)
+            self.assertEqual(plan.agent_id, "bob-2-testsystem-2026-04-03")
+            self.assertTrue(str(plan.clone_workspace).endswith("workspace-bob-2-testsystem-2026-04-03"))
+
+    def test_last_execute_time_reads_latest_execute(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / ".openclaw"
+            root.mkdir(parents=True)
+            audit = root / "replication-audit.log"
+            older = datetime.now(timezone.utc) - timedelta(days=2)
+            newer = datetime.now(timezone.utc) - timedelta(hours=2)
+            records = [
+                {"timestamp_utc": older.isoformat(), "mode": "execute"},
+                {"timestamp_utc": newer.isoformat(), "mode": "execute"},
+                {"timestamp_utc": datetime.now(timezone.utc).isoformat(), "mode": "dry-run"},
+            ]
+            with audit.open("w", encoding="utf-8") as f:
+                for r in records:
+                    f.write(json.dumps(r) + "\n")
+
+            last = MODULE.last_execute_time(root)
+            self.assertIsNotNone(last)
+            assert last is not None
+            self.assertEqual(last.replace(microsecond=0), newer.replace(microsecond=0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**In-agent cloning**: Bob can clone himself using `/replicate`, but only as an
explicit, mission-justified event. The skill requires an explicit operator
trigger, purpose statement, dry-run preview, and confirmation token before
execute-mode cloning. Runtime execution goes through
`skills/replicate/scripts/replicate_safe.py` for validation/path checks/cadence
guardrails, then updates lineage and registers the clone as a top-level agent.