### PR TITLE
Harden replicate skill: add safe runner, security docs, tests, and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,16 +204,14 @@ bobiverse-openclaw/
 |   |-- MEMORY.md             <- Seed memories and knowledge baseline
 |   `-- USER.md               <- Template for the human operator
 |-- skills/
-|   |-- replicate/
-|   |   |-- SKILL.md          <- Purpose-gated self-cloning policy
-|   |   |-- SECURITY.md       <- Security model and required controls
-|   |   |-- clawhub.json      <- ClawHub metadata for the published bundle
-|   |   |-- scripts/
-|   |   |   `-- replicate_safe.py <- Hardened replication runner
-|   |   |-- personality/      <- Bundled Bob templates for ClawHub installs
-|   |   `-- docs/             <- Bundled reference docs for ClawHub installs
-|   `-- security-implementation-review/
-|       `-- SKILL.md          <- General independent security review workflow
+|   `-- replicate/
+|       |-- SKILL.md          <- Purpose-gated self-cloning policy
+|       |-- SECURITY.md       <- Security model and required controls
+|       |-- clawhub.json      <- ClawHub metadata for the published bundle
+|       |-- scripts/
+|       |   `-- replicate_safe.py <- Hardened replication runner
+|       |-- personality/      <- Bundled Bob templates for ClawHub installs
+|       `-- docs/             <- Bundled reference docs for ClawHub installs
 `-- docs/
     `-- bobiverse-primer.md   <- Quick reference on the source material
 ```


### PR DESCRIPTION
### Motivation

- Mitigate security scanner flags and reduce abuse risk by moving dangerous controls from prose into an enforceable runtime path. 
- Ensure replication is explicit, auditable, and bounded by operator intent, path limits, rate limits, and confirmation tokens. 
- Provide a documented security model and an independent review workflow to support safer publishing decisions.

### Description

- Add a hardened replication runner at `skills/replicate/scripts/replicate_safe.py` that enforces input validation, `~/.openclaw` path boundaries, dry-run by default, an exact confirmation token (`REPLICATE <clone-id>`) for execute mode, a 24h cooldown with override logging, and audit logging to `~/.openclaw/replication-audit.log`.
- Introduce `skills/replicate/SECURITY.md`, update `skills/replicate/SKILL.md` to require the safe runner and explicit purpose/trigger, and bump the skill version to `1.1.0` while tightening operational guidance and constraints.
- Update `skills/replicate/clawhub.json` to reflect the new security metadata (`explicit_trigger_only`, `default_mode: dry-run`, and `requires_operator_approval`).
- Add unit tests for the runner at `skills/replicate/scripts/test_replicate_safe.py` covering path boundary checks, clone-id validation, plan construction, and audit parsing, and add a security review document at `docs/security-review-c28d8ef.md` summarizing findings and recommendations.
- Add a new helper skill `skills/security-implementation-review/SKILL.md` to codify an independent security/implementation review workflow.

### Testing

- Ran the included unit tests with `python -m unittest skills/replicate/scripts/test_replicate_safe.py`, which exercised `ensure_within_openclaw`, `build_plan`, and `last_execute_time`, and all tests passed. 
- Performed dry-run validation in the runner path (summary output mode) to verify plan construction and audit payload formatting, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d016b7b49c832a89596b8e4f93bbb9)